### PR TITLE
Make links clickable in chat

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -15,6 +15,39 @@ interface TodoItem {
   message?: string | null;
 }
 
+// Convert URLs in plain text to clickable <a> elements.
+function linkify(text: string) {
+  // Regex matches http/https URLs stopping before trailing punctuation.
+  const urlPattern = /(https?:\/\/[^\s)]+)([)\.,!?]?)/g;
+  const elements: (string | JSX.Element)[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = urlPattern.exec(text)) !== null) {
+    const [full, url, trailing] = match;
+    // Push preceding text
+    if (match.index > lastIndex) {
+      elements.push(text.slice(lastIndex, match.index));
+    }
+    elements.push(
+      <a
+        key={elements.length}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline decoration-primary-500 hover:text-primary-600 break-words"
+      >
+        {url}
+      </a>
+    );
+    if (trailing) elements.push(trailing);
+    lastIndex = match.index + full.length;
+  }
+  if (lastIndex < text.length) {
+    elements.push(text.slice(lastIndex));
+  }
+  return elements;
+}
+
 export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -166,7 +199,7 @@ export default function Chat() {
                 }`}
               >
                 <div className="whitespace-pre-wrap break-words">
-                  {message.content}
+                  {linkify(message.content)}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
**Feature Added/Issue Fixed**
This pull request fixes #3 by making URLs clickable in the chat interface.

**Code Additions/Changes**
* Added the `linkify` function to parse message text and convert detected URLs into clickable `<a>` elements, using a regex to match `http` and `https` URLs and preserve surrounding punctuation. (`frontend/app/page.tsx`)
* Updated the message rendering logic in the `Chat` component to use `linkify` so that URLs in `message.content` are automatically linkified. (`frontend/app/page.tsx`)

**Additional Notes**
None