### PR TITLE
Lifecycle logging for sub-agents

### DIFF
--- a/src/concert_buddy/agents/concert_agent.py
+++ b/src/concert_buddy/agents/concert_agent.py
@@ -6,6 +6,8 @@ from agents import Agent, ModelSettings, WebSearchTool
 from openai.types.shared import Reasoning
 from pydantic import BaseModel
 
+from ..hooks import LoggingHooks
+
 
 class Concert(BaseModel):
     """A live concert event."""
@@ -46,4 +48,5 @@ concert_agent = Agent(
     model_settings=ModelSettings(reasoning=Reasoning(effort="low"), verbosity="low"),
     output_type=Concert,
     tools=[WebSearchTool()],
+    hooks=LoggingHooks(),
 )

--- a/src/concert_buddy/agents/manager_agent.py
+++ b/src/concert_buddy/agents/manager_agent.py
@@ -3,6 +3,7 @@
 from agents import Agent, ModelSettings
 from openai.types.shared import Reasoning
 
+from ..hooks import LoggingHooks
 from ..progress import report_todos, update_todo
 from .concert_agent import concert_agent
 from .playlist_agent import playlist_agent
@@ -81,4 +82,5 @@ manager_agent = Agent(
         report_todos,
         update_todo,
     ],
+    hooks=LoggingHooks(),
 )

--- a/src/concert_buddy/agents/playlist_agent.py
+++ b/src/concert_buddy/agents/playlist_agent.py
@@ -11,6 +11,8 @@ from openai.types.shared import Reasoning
 from pydantic import BaseModel
 from spotipy.oauth2 import SpotifyOAuth  # type: ignore
 
+from ..hooks import LoggingHooks
+
 load_dotenv(override=True)
 
 
@@ -327,4 +329,5 @@ playlist_agent = Agent(
         create_playlist_from_setlist,
         create_playlist_from_artist_top_tracks,
     ],
+    hooks=LoggingHooks(),
 )

--- a/src/concert_buddy/agents/ticket_agent.py
+++ b/src/concert_buddy/agents/ticket_agent.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from agents import Agent, ModelSettings, WebSearchTool
 from openai.types.shared import Reasoning
 
+from ..hooks import LoggingHooks
+
 # A sub-agent specializing on searching for concert tickets
 TICKET_INSTRUCTIONS = f"""You are a concert ticket agent.
 You are skilled in navigating the web to find concert ticket information.
@@ -26,4 +28,5 @@ ticket_agent = Agent(
     model="gpt-5",
     model_settings=ModelSettings(reasoning=Reasoning(effort="low"), verbosity="low"),
     tools=[WebSearchTool()],
+    hooks=LoggingHooks(),
 )

--- a/src/concert_buddy/config/logging_config.py
+++ b/src/concert_buddy/config/logging_config.py
@@ -28,7 +28,11 @@ def setup_logging(level: str = "INFO") -> logging.Logger:
     if logger.handlers:
         return logger
 
-    # File handler - detailed logs
+    # Clear log file on first setup only
+    if LOG_FILE.exists():
+        LOG_FILE.unlink()  # Delete the file
+
+    # File handler - detailed logs (append mode)
     file_handler = logging.FileHandler(LOG_FILE)
     file_handler.setLevel(logging.DEBUG)
     file_formatter = logging.Formatter(

--- a/src/concert_buddy/hooks.py
+++ b/src/concert_buddy/hooks.py
@@ -1,11 +1,11 @@
-"""Logging hooks for agent run lifecycle events."""
+"""Logging hooks for agent lifecycle events."""
 
 from typing import Any, Optional
 
 from agents import (
     Agent,
+    AgentHooks,
     RunContextWrapper,
-    RunHooks,
     Tool,
     Usage,
 )
@@ -14,12 +14,8 @@ from agents.items import ModelResponse, TResponseInputItem
 from .config import logger
 
 
-class LoggingHooks(RunHooks):
-    """Hooks for monitoring agent run lifecycle events."""
-
-    def __init__(self):
-        """Initialize the logging hooks."""
-        pass
+class LoggingHooks(AgentHooks):
+    """Hooks for monitoring agent lifecycle events."""
 
     def _usage_to_str(self, usage: Usage) -> str:
         """Convert token Usage object to a formatted string."""
@@ -28,7 +24,7 @@ class LoggingHooks(RunHooks):
             f"{usage.output_tokens} output tokens, {usage.total_tokens} total tokens"
         )
 
-    async def on_agent_start(self, context: RunContextWrapper, agent: Agent) -> None:
+    async def on_start(self, context: RunContextWrapper, agent: Agent) -> None:
         """Call before the agent is invoked."""
         logger.info(
             "(%s) Agent %s started. Usage: %s",
@@ -57,7 +53,7 @@ class LoggingHooks(RunHooks):
             "(%s) LLM ended. Usage: %s", agent.name, self._usage_to_str(context.usage)
         )
 
-    async def on_agent_end(
+    async def on_end(
         self, context: RunContextWrapper, agent: Agent, output: Any
     ) -> None:
         """Call when the agent produces a final output."""

--- a/src/concert_buddy/server.py
+++ b/src/concert_buddy/server.py
@@ -8,7 +8,6 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from .agents.manager_agent import manager_agent
-from .hooks import LoggingHooks
 from .progress import sse_event_stream
 
 load_dotenv(override=True)
@@ -52,7 +51,6 @@ async def chat(req: ChatRequest):
     result = await Runner.run(
         starting_agent=manager_agent,
         input=prefixed_input,
-        hooks=LoggingHooks(),
         previous_response_id=req.previous_response_id,
     )
     return ChatResponse(


### PR DESCRIPTION
**Feature Added/Issue Fixed**
This pull request adds visibility into lifecycle events for sub-agents by switching from RunHooks to individual AgentHooks for each agent/sub-agent.

**Code Additions/Changes**
* Refactored `LoggingHooks` to inherit from `AgentHooks` instead of `RunHooks`, and renamed lifecycle methods (`on_agent_start`, `on_agent_end`) to match the new interface (`on_start`, `on_end`).
* Added `LoggingHooks` to the `Concert`, `Manager`, `Playlist`, and `Ticket` agents.
* Removed redundant instantiation of `LoggingHooks` in `server.py` since hooks are now attached directly to agents. 
* Modified log file setup to clear the log file on first initialization, ensuring fresh logs for each run.

**Additional Notes**
None