### PR TITLE
Filter out future setlists

### DIFF
--- a/src/concert_buddy/agents/playlist_agent.py
+++ b/src/concert_buddy/agents/playlist_agent.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from datetime import datetime
 
 import spotipy  # type: ignore
 from agents import Agent, ModelSettings, function_tool
@@ -88,9 +89,33 @@ async def search_setlists(artists: list[str]) -> str:
             if not setlists:
                 results += f"**No setlists found for {artist}.**\n"
                 continue
+
+            # Filter out future setlists (only keep past/present events)
+            today = datetime.now().date()
+            past_setlists = []
+            for setlist in setlists:
+                event_date_str = setlist.get("eventDate")
+                if event_date_str:
+                    try:
+                        # Parse date format: "DD-MM-YYYY"
+                        event_date = datetime.strptime(
+                            event_date_str, "%d-%m-%Y"
+                        ).date()
+                        if event_date <= today:
+                            past_setlists.append(setlist)
+                    except (ValueError, TypeError):
+                        # If date parsing fails, skip this setlist
+                        continue
+
+            if not past_setlists:
+                results += f"**No past setlists found for {artist}.**\n"
+                continue
+
             results += (
                 f"**Most recent setlists for {artist}:**\n"
-                + "\n".join(json.dumps(setlist, indent=2) for setlist in setlists[:3])
+                + "\n".join(
+                    json.dumps(setlist, indent=2) for setlist in past_setlists[:10]
+                )
                 + "\n"
             )
     return results

--- a/src/concert_buddy/agents/playlist_agent.py
+++ b/src/concert_buddy/agents/playlist_agent.py
@@ -101,7 +101,7 @@ async def search_setlists(artists: list[str]) -> str:
                         event_date = datetime.strptime(
                             event_date_str, "%d-%m-%Y"
                         ).date()
-                        if event_date <= today:
+                        if event_date < today:
                             past_setlists.append(setlist)
                     except (ValueError, TypeError):
                         # If date parsing fails, skip this setlist


### PR DESCRIPTION
**Feature Added/Issue Fixed**
This pull request fixes #6 by filtering out any setlist results from the Setlist FM API that are from the current day or for future dates. This is to avoid returning results for concerts that haven't taken place yet (i.e., blank setlists).

**Code Additions/Changes**
* Added logic to filter out future setlists by comparing each setlist's `eventDate` to today's date, ensuring only past or present events are included in the results.
* If no past setlists are found for an artist, a message is shown indicating this.
* Imported `datetime` from the standard library to support date parsing and comparison.
* Increased the number of displayed setlists from 3 to up to 10 for each artist, improving the usefulness of the output.

**Additional Notes**
None