### PR TITLE
Update Dockerfiles to be compatible with Google Cloud Run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
+# OpenAI API key
 OPENAI_API_KEY=
+
+# Setlist.fm API key
 SETLIST_FM_API_KEY=
+
+# Spotify API credentials
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
 SPOTIFY_REDIRECT_URI=
+
+# CORS allowed origins for the backend server, in JSON array format
+ALLOW_ORIGINS=["http://localhost:3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ COPY src ./src
 
 RUN uv sync --locked --no-dev
 
-EXPOSE 8000
+EXPOSE 8080
 
-CMD ["uv", "run", "uvicorn", "src.concert_buddy.server:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uv run uvicorn src.concert_buddy.server:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,9 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8000:8080"
     env_file:
       - .env
-    environment:
-      UVICORN_HOST: 0.0.0.0
-      UVICORN_PORT: 8000
-      ALLOW_ORIGINS: '["http://localhost:3000"]'
 
   frontend:
     build:
@@ -19,6 +15,6 @@ services:
     depends_on:
       - backend
     ports:
-      - "3000:3000"
+      - "3000:8080"
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://backend:8000
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,6 @@ COPY . .
 
 RUN npm run build
 
-EXPOSE 3000
+EXPOSE 8080
 
-CMD ["npm", "run", "start"]
+CMD ["sh", "-c", "npm run start -- --port ${PORT:-8080}"]

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -131,7 +131,7 @@ export default function Chat() {
       console.error("Error sending message:", error);
       const errorMessage: Message = {
         role: "assistant",
-        content: "Sorry, I encountered an error. Please make sure the backend server is running on http://localhost:8000",
+        content: `Sorry, I encountered an error. Please make sure the backend server is running on ${API_BASE_URL}`,
       };
       setMessages((prev) => [...prev, errorMessage]);
     } finally {


### PR DESCRIPTION
Updated Dockerfiles to be compatible with Google Cloud Run for deployment.

### Code Changes
- `frontend/Dockerfile` and `Dockerfile` now start with configurable port, to accept `PORT` value injected by Cloud Run. Exposes port 8080 on both.
- `docker-compose.yml` maps backend host-to-container ports as `8000:8080` and frontend `3000:8080`.
- `docker-compose.yml` now sets frontend env explicitly 
- Updated `.env.example` to include CORS allowed origins, removed from `docker-compose.yml`.
- Replaced hardcoded backend URL in `frontend/app/page.tsx` and replaced with `API_BASE_URL` variable.